### PR TITLE
Platform locations

### DIFF
--- a/pkpic_gtfs/app.py
+++ b/pkpic_gtfs/app.py
@@ -22,6 +22,7 @@ from .gtfs import GTFS_HEADERS
 from .load_csv import LoadCSV
 from .load_stations import LoadStationData
 from .simplify_routes import SimplifyRoutes
+from .load_platforms import LoadPlatformData
 
 
 class PKPIntercityGTFS(App):
@@ -53,6 +54,7 @@ class PKPIntercityGTFS(App):
                     task_name="RemoveBohuminVrbice",
                 ),
                 LoadStationData(),
+                LoadPlatformData(),
                 SimplifyRoutes(),
                 GenerateTripHeadsign(),
                 SplitTripLegs(replacement_bus_short_name_pattern=re.compile(r"\bZKA\b", re.I)),
@@ -67,6 +69,9 @@ class PKPIntercityGTFS(App):
                 ),
                 "pl_rail_map.osm": HTTPResource.get(
                     "https://raw.githubusercontent.com/MKuranowski/PLRailMap/master/plrailmap.osm"
+                ),
+                "platforms.json": HTTPResource.get(
+                    "https://kasmar00.github.io/osm-plk-platform-validator/platforms-list.json"
                 ),
                 "routes.csv": LocalResource("data/routes.csv"),
             },

--- a/pkpic_gtfs/gtfs.py
+++ b/pkpic_gtfs/gtfs.py
@@ -10,7 +10,7 @@ GTFS_HEADERS = {
         "agency_lang",
         "agency_phone",
     ),
-    "stops.txt": ("stop_id", "stop_name", "stop_lat", "stop_lon"),
+    "stops.txt": ("stop_id", "stop_name", "stop_lat", "stop_lon", "platform_code"),
     "routes.txt": (
         "agency_id",
         "route_id",

--- a/pkpic_gtfs/load_csv.py
+++ b/pkpic_gtfs/load_csv.py
@@ -127,6 +127,8 @@ def parse_train(rows: list[CSVRow]) -> tuple[Trip, list[StopTime]]:
         else:
             platform = normalize_platform(row["PeronWyjazd"] or row["PeronWjazd"])
 
+        track = row["TorWjazd"] or row["TorWyjazd"]
+
         stop_time = StopTime(
             trip_id=trip_id,
             stop_id=stop_id,
@@ -134,7 +136,7 @@ def parse_train(rows: list[CSVRow]) -> tuple[Trip, list[StopTime]]:
             arrival_time=TimePoint(seconds=arr),
             departure_time=TimePoint(seconds=dep),
             platform=platform,
-            extra_fields_json=json.dumps({"fare_dist_m": str(dist)}),
+            extra_fields_json=json.dumps({"fare_dist_m": str(dist), "track": track}),
         )
 
         stop_times.append(stop_time)

--- a/pkpic_gtfs/load_platforms.py
+++ b/pkpic_gtfs/load_platforms.py
@@ -1,0 +1,56 @@
+import impuls
+import json
+
+class LoadPlatformData(impuls.Task):
+    def __init__(self) -> None:
+        super().__init__()
+    
+    @staticmethod
+    def load_platforms(path: impuls.tools.types.StrPath) -> None:
+        with open(path, "r", encoding="utf-8") as f:
+            platforms = json.load(f)
+        return platforms
+
+    def execute(self, r: impuls.TaskRuntime) -> None:
+        platforms_in_db = r.db.raw_execute(
+            """
+        SELECT DISTINCT name, stop_id, json_extract(stop_times.extra_fields_json, '$.track') AS track
+        FROM stop_times join stops USING (stop_id)
+        WHERE track IS NOT NULL and track is not ''
+        """
+        ).all()
+        print(f"Found {len(platforms_in_db)} platforms in DB")
+        print(platforms_in_db[:10])
+        platforms = self.load_platforms(r.resources["platforms.json"].stored_at)
+        for name, stop_id, track in platforms_in_db:
+            platform_id = f"{stop_id}_{track}"
+            platform = [platform for platform in  platforms.get(name, []) if platform.get("track") == track]
+            if len(platform)>0:
+                platform = platform[0]
+                location = platform.get("location")
+                if not location:
+                    print(f"Platform {name} track {track} has no location")
+                    parent_stop = r.db.retrieve_must(impuls.model.Stop, stop_id)
+                    location = [parent_stop.lon, parent_stop.lat]
+
+                r.db.create(
+                    impuls.model.Stop(
+                        id=platform_id,
+                        name=name,
+                        parent_station=stop_id,
+                        location_type=0, #TODO: set 1 for parent station?
+                        platform_code=f"{platform.get('platform')}/{track}",
+                        lon=location[0],
+                        lat=location[1],
+                    )
+                )
+                r.db.raw_execute(
+                    """
+                UPDATE stop_times
+                SET stop_id = ?
+                WHERE stop_id = ? AND json_extract(extra_fields_json, '$.track') = ?
+                """,
+                    (platform_id, stop_id, track),
+                )
+            else:
+                print(f"Platform not found for {name} track {track}")


### PR DESCRIPTION
Initial approach to adding platform (track) numbering and locations.

Platform/track locations are sourced from my project: https://github.com/kasmar00/osm-plk-platform-validator, which generates track and platform pairs based on [PLK ](https://www.plk-sa.pl/klienci-i-kontrahenci/warunki-udostepniania-infrastruktury-i-regulaminy/regulamin-sieci/regulamin-sieci-2024/2025) data (which has a few issues but is good enough to treat it as authoritative) and OSM data (stop locations on tracks).
There are around 15% of tracks missing in overall data, but some are single track stops, stops/stations disused for many years (somehow still in PLK data) or stops temporarily in construction. Fortunately most are not served by PKP IC and for PKP IC only around 30 tracks are missing (location of parent station is used) and no stations are missing.

Let me know what's your general opinion on adding platform/track locations. I'm happy to work on this code further to have it merged😃(And I already see that there're a few places where terminology should be unified.